### PR TITLE
Setup CICD for Firefox extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Build and Publish Support Canadian Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build and Package Extension
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      
+      - name: Build Extension
+        id: web-ext-build
+        uses: kewisch/action-web-ext@v1.3
+        with:
+          cmd: build
+          source: .
+          filename: "support_canadian.zip"
+
+      - name: Upload XPI Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: support-canadian-extension
+          path: ${{ steps.web-ext-build.outputs.target }}
+
+  publish:
+    name: Publish to Firefox AMO and Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      
+      - name: Download Built XPI
+        uses: actions/download-artifact@v4
+        with:
+          name: support-canadian-extension
+          path: build/
+
+      - name: Publish to Firefox Add-ons (AMO)
+        id: web-ext-sign
+        uses: kewisch/action-web-ext@v1.3
+        with:
+          cmd: sign
+          source: build/support_canadian.zip
+          channel: listed  # Use "unlisted" if this is the first submission
+          apiKey: ${{ secrets.AMO_API_KEY }}
+          apiSecret: ${{ secrets.AMO_API_SECRET }}
+          timeout: 900000  # 15 minutes
+
+      - name: Create GitHub Release with Unsigned Artifact
+        if: always()  # Ensures this step runs regardless of previous step outcomes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} build/support_canadian.zip \
+            --title "Release ${{ github.ref_name }}" \
+            --notes "This release contains the unsigned build artifact. A signed version will be updated once Firefox review is complete."


### PR DESCRIPTION
Go to https://addons.mozilla.org/en-US/developers/addon/api/key/ and generate the key.
Setup the key as per the variable names below in the settings. 

Will add more stuff later. 